### PR TITLE
Remove deprecated endpoint

### DIFF
--- a/OvhCloudTransport.php
+++ b/OvhCloudTransport.php
@@ -34,7 +34,6 @@ final class OvhCloudTransport extends AbstractTransport
         'kimsufi-ca' => 'https://ca.api.kimsufi.com/1.0',
         'soyoustart-eu' => 'https://eu.api.soyoustart.com/1.0',
         'soyoustart-ca' => 'https://ca.api.soyoustart.com/1.0',
-        'runabove-ca' => 'https://api.runabove.com/1.0',
     ];
 
     private $applicationKey;


### PR DESCRIPTION
Runabove has been closed so that's why I suggest to remove it from the endpoint list.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>